### PR TITLE
Fix group resources for a default prefix

### DIFF
--- a/test.js
+++ b/test.js
@@ -224,6 +224,36 @@ test('should group resources using `.groupResources`', function (done) {
     })
 })
 
+test('should generate correct routes using `.groupResources` for a default prefix', function () {
+  let apiRouter = new Router()
+  let companies = apiRouter.createResource('companies')
+  let profiles = apiRouter.createResource('profiles')
+
+  let resource = apiRouter.groupResources(companies, profiles)
+
+  test.strictEqual(resource[0].path, '/companies/:company/profiles')
+  test.strictEqual(resource[1].path, '/companies/:company/profiles/new')
+  test.strictEqual(resource[2].path, '/companies/:company/profiles')
+  test.strictEqual(resource[3].path, '/companies/:company/profiles/:profile')
+  test.strictEqual(resource[4].path, '/companies/:company/profiles/:profile/edit')
+  test.strictEqual(resource[5].path, '/companies/:company/profiles/:profile')
+})
+
+test('should generate correct routes using `.groupResources` for a custom prefix', function () {
+  let apiRouter = new Router({ prefix: '/api' })
+  let companies = apiRouter.createResource('companies')
+  let profiles = apiRouter.createResource('profiles')
+
+  let resource = apiRouter.groupResources(companies, profiles)
+
+  test.strictEqual(resource[0].path, '/api/companies/:company/profiles')
+  test.strictEqual(resource[1].path, '/api/companies/:company/profiles/new')
+  test.strictEqual(resource[2].path, '/api/companies/:company/profiles')
+  test.strictEqual(resource[3].path, '/api/companies/:company/profiles/:profile')
+  test.strictEqual(resource[4].path, '/api/companies/:company/profiles/:profile/edit')
+  test.strictEqual(resource[5].path, '/api/companies/:company/profiles/:profile')
+})
+
 test('should be able to re-map controller methods through opitons', function (done) {
   let options = {
     map: {

--- a/utils.js
+++ b/utils.js
@@ -24,7 +24,10 @@ utils.updateRoute = function updateRoute (ctx, destRoute) {
   let route = destRoute.route.slice(1)
   /* istanbul ignore next */
   if (!route.length) return '/:id'
-  route = route.replace(ctx.options.prefix, '')
+
+  if (ctx.options.prefix !== '/') {
+    route = route.replace(ctx.options.prefix, '')
+  }
 
   let res = []
   let singular = null


### PR DESCRIPTION
First of all big thx to @bit-marcink who found this bug.

Now to the point.
When you're using `groupResources` for a router with default prefix (`/`)  it will mess up routes because will remove first slash path https://github.com/olstenlarck/koa-rest-router/blob/769c47a19b8bd735ab8a83297d61e0be2803a603/utils.js#L27

In general it looks to me like this line is not necessary because https://github.com/olstenlarck/koa-rest-router/blob/769c47a19b8bd735ab8a83297d61e0be2803a603/utils.js#L24 first char (`/`) is removed so you will never have correct prefix at beginning of a path, but maybe it's for some other use case/edge case so I put it in condition just to be on safe side. Anyway tests are passing even if you remove `route = route.replace(ctx.options.prefix, '')` completely. 
